### PR TITLE
Add chess web server with token support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,40 @@
 # MyChess
+
+MyChess provides a simple online chess experience with integrated AI analysis. It uses [python-chess](https://github.com/niklasf/python-chess) and the Stockfish engine.
+
+## Features
+
+- **Play vs Engine**: Web interface to play against Stockfish.
+- **Rating Tracking**: Player ratings are updated using the ELO algorithm after each game. Ratings, token counts and premium status are stored in `players.json`.
+- **Puzzles**: Run `python puzzles.py` to get a random tactical puzzle.
+- **Analysis API**: Submit positions for engine analysis using `/analysis`.
+
+## Requirements
+
+- Python 3.12+
+- `python-chess` library
+- `Flask` web framework
+- Stockfish engine available in your PATH
+
+Install dependencies with:
+
+```bash
+pip install flask python-chess
+sudo apt-get install stockfish
+```
+
+## Usage
+
+Run the web server and open `http://localhost:5000` in your browser:
+
+```bash
+python app.py
+```
+
+Solve a random puzzle from the command line:
+
+```bash
+python puzzles.py
+```
+
+Player ratings, token usage and history are stored in `players.json`.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,61 @@
+import chess
+import chess.engine
+from flask import Flask, request, jsonify, send_from_directory
+from rating import load_players, save_players, ensure_player, use_token
+
+STOCKFISH_PATH = "/usr/games/stockfish"
+engine = chess.engine.SimpleEngine.popen_uci(STOCKFISH_PATH)
+
+app = Flask(__name__, static_folder="static")
+
+@app.route("/")
+def index():
+    return send_from_directory(app.static_folder, "index.html")
+
+@app.route("/move", methods=["POST"])
+def move():
+    data = request.get_json(force=True)
+    player = data.get("player", "guest")
+    fen = data.get("fen")
+    move_uci = data.get("move")
+    if not fen or not move_uci:
+        return jsonify({"error": "missing parameters"}), 400
+    board = chess.Board(fen)
+    try:
+        move = chess.Move.from_uci(move_uci)
+    except ValueError:
+        return jsonify({"error": "invalid move"}), 400
+    if move not in board.legal_moves:
+        return jsonify({"error": "illegal move"}), 400
+    players = load_players()
+    ensure_player(players, player)
+    if not use_token(players, player):
+        save_players(players)
+        return jsonify({"error": "out of tokens"}), 402
+    board.push(move)
+    result = engine.play(board, chess.engine.Limit(time=0.1))
+    board.push(result.move)
+    save_players(players)
+    return jsonify({"engine_move": result.move.uci(), "fen": board.fen()})
+
+@app.route("/analysis", methods=["POST"])
+def analysis():
+    data = request.get_json(force=True)
+    player = data.get("player", "guest")
+    fen = data.get("fen")
+    if not fen:
+        return jsonify({"error": "missing fen"}), 400
+    board = chess.Board(fen)
+    players = load_players()
+    ensure_player(players, player)
+    if not use_token(players, player):
+        save_players(players)
+        return jsonify({"error": "out of tokens"}), 402
+    info = engine.analyse(board, chess.engine.Limit(depth=12))
+    best = info["pv"][0]
+    score = info["score"].white().score(mate_score=10000)
+    save_players(players)
+    return jsonify({"best_move": best.uci(), "score": score})
+
+if __name__ == "__main__":
+    app.run(debug=True)

--- a/chess_game.py
+++ b/chess_game.py
@@ -1,0 +1,52 @@
+import chess
+import chess.engine
+import sys
+from pathlib import Path
+from rating import load_players, record_result
+
+STOCKFISH_PATH = "/usr/games/stockfish"
+
+
+def play_game(player_name):
+    board = chess.Board()
+    players = load_players()
+    engine = chess.engine.SimpleEngine.popen_uci(STOCKFISH_PATH)
+
+    try:
+        while not board.is_game_over():
+            print(board)
+            if board.turn == chess.WHITE:
+                move_str = input("Your move (in UCI, e.g. e2e4): ")
+                try:
+                    move = chess.Move.from_uci(move_str)
+                except ValueError:
+                    print("Invalid move format. Try again.")
+                    continue
+                if move not in board.legal_moves:
+                    print("Illegal move. Try again.")
+                    continue
+                board.push(move)
+            else:
+                result = engine.play(board, chess.engine.Limit(time=0.1))
+                board.push(result.move)
+                print(f"Engine plays: {result.move}")
+    finally:
+        engine.quit()
+
+    print(board)
+    result = board.result()
+    print("Game over:", result)
+
+    if result == "1-0":
+        record_result(players, player_name, "engine", 1)
+    elif result == "0-1":
+        record_result(players, player_name, "engine", 0)
+    else:
+        record_result(players, player_name, "engine", 0.5)
+
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        print("Usage: python chess_game.py <player_name>")
+        sys.exit(1)
+    play_game(sys.argv[1])

--- a/puzzles.py
+++ b/puzzles.py
@@ -1,0 +1,28 @@
+import random
+import chess
+
+PUZZLES = [
+    # Each puzzle is a FEN and the best move for White
+    ("r1bqkbnr/pppppppp/n7/8/1P6/5N2/P1PPPPPP/RNBQKB1R b KQkq - 1 2", "a6b4"),
+    ("r2q1rk1/pp2bppp/1nn1p3/2ppP3/3P4/2P1BN2/PP3PPP/RNBQ1RK1 w - - 0 9", "f3d2"),
+    ("r4rk1/ppp2ppp/2n2n2/3q4/3P4/2N1PN2/PPQ2PPP/R3KB1R w KQ - 3 11", "c3xd5"),
+]
+
+
+def random_puzzle():
+    fen, move = random.choice(PUZZLES)
+    board = chess.Board(fen)
+    return board, chess.Move.from_uci(move)
+
+
+def show_puzzle():
+    board, solution = random_puzzle()
+    print(board)
+    guess = input("Your move (UCI): ")
+    if guess == solution.uci():
+        print("Correct!")
+    else:
+        print(f"Wrong. Solution is {solution}")
+
+if __name__ == "__main__":
+    show_puzzle()

--- a/rating.py
+++ b/rating.py
@@ -1,0 +1,67 @@
+import json
+from pathlib import Path
+from datetime import datetime
+
+DATA_FILE = Path("players.json")
+
+
+def load_players():
+    if DATA_FILE.exists():
+        with open(DATA_FILE, "r", encoding="utf-8") as f:
+            return json.load(f)
+    return {}
+
+
+def save_players(players):
+    with open(DATA_FILE, "w", encoding="utf-8") as f:
+        json.dump(players, f, indent=2)
+
+
+def update_elo(rating_a, rating_b, result, k=32):
+    expected_a = 1 / (1 + 10 ** ((rating_b - rating_a) / 400))
+    expected_b = 1 - expected_a
+    new_a = rating_a + k * (result - expected_a)
+    new_b = rating_b + k * ((1 - result) - expected_b)
+    return round(new_a), round(new_b)
+
+
+def ensure_player(players, name):
+    players.setdefault(name, {
+        "rating": 1200,
+        "history": [],
+        "tokens": 10,
+        "premium": False,
+    })
+
+
+def use_token(players, name):
+    player = players.get(name)
+    if not player:
+        ensure_player(players, name)
+        player = players[name]
+    if player.get("premium"):
+        return True
+    if player.get("tokens", 0) > 0:
+        player["tokens"] -= 1
+        return True
+    return False
+
+
+def record_result(players, player_a, player_b, result):
+    # result: 1 if A wins, 0 if B wins, 0.5 draw
+    ensure_player(players, player_a)
+    ensure_player(players, player_b)
+
+    rating_a = players[player_a]["rating"]
+    rating_b = players[player_b]["rating"]
+
+    new_a, new_b = update_elo(rating_a, rating_b, result)
+    players[player_a]["rating"] = new_a
+    players[player_b]["rating"] = new_b
+
+    now = datetime.utcnow().isoformat()
+    players[player_a]["history"].append({"time": now, "rating": new_a})
+    players[player_b]["history"].append({"time": now, "rating": new_b})
+
+    save_players(players)
+

--- a/static/index.html
+++ b/static/index.html
@@ -1,0 +1,65 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>MyChess Online</title>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/chessboard-js/1.0.0/css/chessboard.min.css" integrity="sha512-F6MNWmPZdcDCtfAFnrCHcSu7JlM6axPlHAnGvTdihcLosdINZZe9RJVGnpBevIQHJsg7lvoSOpkMl+vjx5Uu5g==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/chess.js/0.13.4/chess.min.js" integrity="sha512-9TU8M4it/9V6+yYjc7SXIJUJ4MshKgHdwNwp0UrEGouGZWlznImPi0tLxe3Ljpsp8dkUBaRdOy+nK8BPdZvJ4w==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/chessboard-js/1.0.0/js/chessboard.min.js" integrity="sha512-4d0zJRnOj/54eB1xWx0LydSfaXI9bFR1QoSYcxiv+VLVVoQcTASbT8jYtCetZypqjdZEyx+yOjDQAmzv3dw0bQ==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+</head>
+<body>
+<h1>MyChess</h1>
+<div id="board" style="width: 400px;"></div>
+<button id="reset">Reset</button>
+<script>
+var board = null;
+var game = new Chess();
+
+function onDragStart(source, piece) {
+  if (game.game_over() || piece.search(/^b/) !== -1) {
+    return false;
+  }
+}
+
+function onDrop(source, target) {
+  var oldFen = game.fen();
+  var move = game.move({from: source, to: target, promotion: 'q'});
+  if (move === null) return 'snapback';
+  board.position(game.fen());
+  var payload = {
+    player: 'guest',
+    fen: oldFen,
+    move: move.from + move.to + (move.promotion ? move.promotion : '')
+  };
+  fetch('/move', {
+    method: 'POST',
+    headers: {'Content-Type': 'application/json'},
+    body: JSON.stringify(payload)
+  }).then(r => r.json()).then(data => {
+    if (data.engine_move) {
+      game.move(data.engine_move);
+      board.position(game.fen());
+    }
+  });
+}
+
+function onSnapEnd() {
+  board.position(game.fen());
+}
+
+var config = {
+  draggable: true,
+  position: 'start',
+  onDragStart: onDragStart,
+  onDrop: onDrop,
+  onSnapEnd: onSnapEnd
+};
+board = Chessboard('board', config);
+
+document.getElementById('reset').addEventListener('click', function() {
+  game.reset();
+  board.start();
+});
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- expand README for online play instructions
- add Flask web app with play and analysis routes
- store tokens and premium flag for each player
- simple HTML frontend using chessboard.js

## Testing
- `python puzzles.py <<'EOF'
a6b4
EOF`
- `python -m py_compile chess_game.py puzzles.py rating.py app.py`


------
https://chatgpt.com/codex/tasks/task_e_6860b006998883249d6aa763ff22760f